### PR TITLE
Add back Base64 styling support

### DIFF
--- a/django_large_image/rest/params.py
+++ b/django_large_image/rest/params.py
@@ -66,7 +66,7 @@ scheme = openapi.Parameter(
 style = openapi.Parameter(
     'style',
     openapi.IN_QUERY,
-    description='Encoded string of JSON style following https://girder.github.io/large_image/tilesource_options.html#style',
+    description='Encoded string of JSON style following https://girder.github.io/large_image/tilesource_options.html#style . This can optionally be Base64 encoded if too large for URL.',
     type=openapi.TYPE_STRING,
 )
 

--- a/django_large_image/utilities.py
+++ b/django_large_image/utilities.py
@@ -1,3 +1,4 @@
+import base64
 from contextlib import contextmanager
 import logging
 import os
@@ -147,3 +148,17 @@ def field_file_to_local_path(field_file: FieldFile) -> pathlib.Path:
             logger.debug('Marking as safely downloaded...')
             safe.touch()
     return dest_path
+
+
+def is_base64(sb):
+    try:
+        if isinstance(sb, str):
+            # If there's any unicode here, an exception will be thrown
+            sb_bytes = bytes(sb, 'ascii')
+        elif isinstance(sb, bytes):
+            sb_bytes = sb
+        else:
+            raise ValueError
+        return base64.b64encode(base64.b64decode(sb_bytes)) == sb_bytes
+    except Exception:
+        return False

--- a/project/example/core/tests/test_style.py
+++ b/project/example/core/tests/test_style.py
@@ -1,3 +1,4 @@
+import base64
 import json
 from urllib.parse import quote
 
@@ -16,6 +17,22 @@ def test_style_parameters(authenticated_api_client, image_file_geotiff):
     )
     assert response.status_code == 200
     assert response['Content-Type'] == 'image/png'
+
+
+@pytest.mark.django_db(transaction=True)
+def test_style_base64(authenticated_api_client, image_file_geotiff):
+    style = {
+        'bands': [
+            {'band': 1, 'palette': ['#000', '#0f0']},
+        ]
+    }
+    style_base64 = base64.urlsafe_b64encode(json.dumps(style).encode()).decode()
+    response = authenticated_api_client.get(
+        f'/api/image-file/{image_file_geotiff.pk}/thumbnail.png?style={style_base64}',
+    )
+    assert response.status_code == 200
+    assert response['Content-Type'] == 'image/png'
+    # TODO: might want to verify style was actually used
 
 
 @pytest.mark.django_db(transaction=True)

--- a/project/example/core/tests/test_style.py
+++ b/project/example/core/tests/test_style.py
@@ -26,7 +26,7 @@ def test_style_base64(authenticated_api_client, image_file_geotiff):
             {'band': 1, 'palette': ['#000', '#0f0']},
         ]
     }
-    style_base64 = base64.urlsafe_b64encode(json.dumps(style).encode()).decode()
+    style_base64 = quote(base64.urlsafe_b64encode(json.dumps(style).encode()).decode())
     response = authenticated_api_client.get(
         f'/api/image-file/{image_file_geotiff.pk}/thumbnail.png?style={style_base64}',
     )


### PR DESCRIPTION
This reverts commit 3c74b7f37a5d91f68048fe5a907eedb2ead734f0.

Take the following style object:

```js
{
    "bands": [
        {
            "frame": 0,
            "palette": "#ffffff"
        },
        {
            "frame": 1,
            "palette": "#ffffff"
        },
        {
            "frame": 2,
            "palette": "#ffffff"
        },
        {
            "frame": 3,
            "palette": "#ffffff"
        },
        {
            "frame": 4,
            "palette": "#ffffff"
        },
        {
            "frame": 5,
            "palette": "#ffffff"
        },
        {
            "frame": 6,
            "palette": "#ffffff"
        },
        {
            "frame": 7,
            "palette": "#ffffff"
        },
        {
            "frame": 8,
            "palette": "#ffffff"
        },
        {
            "frame": 9,
            "palette": "#ffffff"
        },
        {
            "frame": 10,
            "palette": "#ffffff"
        },
        {
            "frame": 11,
            "palette": "#ffffff"
        }
    ]
}
```

Base64 encoding of this object is smaller than the URI encoded version (and is so in all similar examples I have tried)

JSON Stringify (length 397):
```
{"bands":[{"frame":0,"palette":"#ffffff"},{"frame":1,"palette":"#ffffff"},{"frame":2,"palette":"#ffffff"},{"frame":3,"palette":"#ffffff"},{"frame":4,"palette":"#ffffff"},{"frame":5,"palette":"#ffffff"},{"frame":6,"palette":"#ffffff"},{"frame":7,"palette":"#ffffff"},{"frame":8,"palette":"#ffffff"},{"frame":9,"palette":"#ffffff"},{"frame":10,"palette":"#ffffff"},{"frame":11,"palette":"#ffffff"}]}
```

Base64 (length 532):
```
eyJiYW5kcyI6W3siZnJhbWUiOjAsInBhbGV0dGUiOiIjZmZmZmZmIn0seyJmcmFtZSI6MSwicGFsZXR0ZSI6IiNmZmZmZmYifSx7ImZyYW1lIjoyLCJwYWxldHRlIjoiI2ZmZmZmZiJ9LHsiZnJhbWUiOjMsInBhbGV0dGUiOiIjZmZmZmZmIn0seyJmcmFtZSI6NCwicGFsZXR0ZSI6IiNmZmZmZmYifSx7ImZyYW1lIjo1LCJwYWxldHRlIjoiI2ZmZmZmZiJ9LHsiZnJhbWUiOjYsInBhbGV0dGUiOiIjZmZmZmZmIn0seyJmcmFtZSI6NywicGFsZXR0ZSI6IiNmZmZmZmYifSx7ImZyYW1lIjo4LCJwYWxldHRlIjoiI2ZmZmZmZiJ9LHsiZnJhbWUiOjksInBhbGV0dGUiOiIjZmZmZmZmIn0seyJmcmFtZSI6MTAsInBhbGV0dGUiOiIjZmZmZmZmIn0seyJmcmFtZSI6MTEsInBhbGV0dGUiOiIjZmZmZmZmIn1dfQ==
```

encodeURIComponent (length 721):
```
%7B%22bands%22%3A%5B%7B%22frame%22%3A0%2C%22palette%22%3A%22%23ffffff%22%7D%2C%7B%22frame%22%3A1%2C%22palette%22%3A%22%23ffffff%22%7D%2C%7B%22frame%22%3A2%2C%22palette%22%3A%22%23ffffff%22%7D%2C%7B%22frame%22%3A3%2C%22palette%22%3A%22%23ffffff%22%7D%2C%7B%22frame%22%3A4%2C%22palette%22%3A%22%23ffffff%22%7D%2C%7B%22frame%22%3A5%2C%22palette%22%3A%22%23ffffff%22%7D%2C%7B%22frame%22%3A6%2C%22palette%22%3A%22%23ffffff%22%7D%2C%7B%22frame%22%3A7%2C%22palette%22%3A%22%23ffffff%22%7D%2C%7B%22frame%22%3A8%2C%22palette%22%3A%22%23ffffff%22%7D%2C%7B%22frame%22%3A9%2C%22palette%22%3A%22%23ffffff%22%7D%2C%7B%22frame%22%3A10%2C%22palette%22%3A%22%23ffffff%22%7D%2C%7B%22frame%22%3A11%2C%22palette%22%3A%22%23ffffff%22%7D%5D%7D
```

If syles get more complex, they may quickly approach the common limit of 1024 characters for query strings.  Having support for Base64 will give users a little more wiggle room to make sure their styles don't exceed limits set by their web server.

Related: https://github.com/atlascope/atlascope/pull/139#pullrequestreview-946184928

