### PR TITLE
Don't use `setuptools` to get package version

### DIFF
--- a/django_large_image/__init__.py
+++ b/django_large_image/__init__.py
@@ -1,7 +1,3 @@
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import version
 
-try:
-    __version__ = get_distribution('django-large-image').version
-except DistributionNotFound:  # pragma: no cover
-    # package is not installed
-    __version__ = ''
+__version__ = version('django-large-image')

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ else:
 
 setup(
     name='django-large-image',
-    version='0.10.0',
+    version='0.10.1',
     description='Dynamic tile server in Django built on top of large-image (and GDAL)',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
`setuptools` isn't listed as an explicit dependency, so it (and `pkg_resources`) may not always be installed. `importlib.metadata` provides the same mechanism to get a package version and is available since Python 3.8.

Fixes #51.