### PR TITLE
Pass frame value to `getTile`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
+      - name: Install ghostscript
+        # test_thumbnail[eps] requires ghostscript
+        run: sudo apt-get install -y ghostscript
       - name: Install tox
         run: |
           pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           - 5432:5432
       minio:
         # This image does not require any command arguments (which GitHub Actions don't support)
-        image: bitnami/minio:2022.3.5-debian-10-r3
+        image: bitnamilegacy/minio
         env:
           MINIO_ROOT_USER: minioAccessKey
           MINIO_ROOT_PASSWORD: minioSecretKey
@@ -75,7 +75,7 @@ jobs:
           - 5432:5432
       minio:
         # This image does not require any command arguments (which GitHub Actions don't support)
-        image: bitnami/minio:2022.3.5-debian-10-r3
+        image: bitnamilegacy/minio
         env:
           MINIO_ROOT_USER: minioAccessKey
           MINIO_ROOT_PASSWORD: minioSecretKey

--- a/django_large_image/rest/data.py
+++ b/django_large_image/rest/data.py
@@ -34,7 +34,7 @@ class DataMixin(LargeImageMixinBase):
     def thumbnail(
         self, request: Request, pk: int = None, fmt: str = 'png', **kwargs
     ) -> HttpResponse:
-        encoding = tilesource.format_to_encoding(fmt)
+        encoding = tilesource.format_to_encoding(fmt, True)
         width = int(self.get_query_param(request, 'max_width', 256))
         height = int(self.get_query_param(request, 'max_height', 256))
         source = self.get_tile_source(request, pk, encoding=encoding)

--- a/django_large_image/rest/serializers.py
+++ b/django_large_image/rest/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+
 from django_large_image import tilesource
 
 

--- a/django_large_image/rest/serializers.py
+++ b/django_large_image/rest/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from django_large_image import tilesource
 
 
 class TileMetadataSerializer(serializers.Serializer):
@@ -30,8 +31,11 @@ class TileMetadataSerializer(serializers.Serializer):
         read_only=True,
         source='dli_geospatial',
     )
-    additional_metadata = serializers.JSONField(
+    additional_metadata = serializers.SerializerMethodField(
+        'get_additional_metadata',
         help_text='Any additional metadata on the tile source.',
         read_only=True,
-        source='getMetadata',
     )
+
+    def get_additional_metadata(self, source):
+        return tilesource.get_metadata(source)

--- a/django_large_image/rest/tiles.py
+++ b/django_large_image/rest/tiles.py
@@ -48,8 +48,9 @@ class TilesMixin(LargeImageMixinBase):
     ) -> HttpResponse:
         encoding = tilesource.format_to_encoding(fmt, pil_safe=True)
         source = self.get_tile_source(request, pk, encoding=encoding)
+        style = self.get_style(request) or {}
         try:
-            tile_binary = source.getTile(int(x), int(y), int(z))
+            tile_binary = source.getTile(int(x), int(y), int(z), frame=style.get('frame'))
         except TileSourceXYZRangeError as e:
             raise ValidationError(e)
         mime_type = source.getTileMimeType()

--- a/django_large_image/rest/tiles.py
+++ b/django_large_image/rest/tiles.py
@@ -49,8 +49,9 @@ class TilesMixin(LargeImageMixinBase):
         encoding = tilesource.format_to_encoding(fmt, pil_safe=True)
         source = self.get_tile_source(request, pk, encoding=encoding)
         style = self.get_style(request) or {}
+        frame = request.query_params.get('frame') or style.get('frame')
         try:
-            tile_binary = source.getTile(int(x), int(y), int(z), frame=style.get('frame'))
+            tile_binary = source.getTile(int(x), int(y), int(z), frame=frame)
         except TileSourceXYZRangeError as e:
             raise ValidationError(e)
         mime_type = source.getTileMimeType()

--- a/django_large_image/tilesource.py
+++ b/django_large_image/tilesource.py
@@ -61,6 +61,8 @@ def get_bounds(
 
 def _metadata_helper(source: FileTileSource, metadata: dict):
     metadata.setdefault('geospatial', is_geospatial(source))
+    if metadata.get('projection'):
+        metadata['projection'] = str(metadata['projection'])
     if metadata['geospatial']:
         metadata['bounds'] = get_bounds(source)
         # metadata['proj4'] = (source.getProj4String(),)  # not supported by rasterio


### PR DESCRIPTION
When using `django-large-image` to get tiles from a multiframe image, the `frame` value should be passed to the `getTile` call, not just the style. This PR makes a small change to ensure that any `frame` value passed to the style will also get passed to the `getTile` call.

To illustrate the difference in behavior, an example multiframe geospatial image ([download here](https://data.kitware.com/api/v1/item/68f12a47bf0f869935e364a5/download)) has transparency applied to nodata values. 
```
import large_image

path = 'flood_transparency_test.tif'
projection = 'epsg:3857'
tile_params = dict(x=619, y=757, z=11)
style = dict(palette='viridis', nodata=-1, min=0, max=1)
frame = 5
```

The following images are examples of the difference between passing `frame` as a tile param versus a style param.

As a tile param:
```
src = large_image.open(path, projection=projection, style=style, encoding='PNG')
tile = src.getTile(**tile_params, frame=frame)
```
<img width="256" height="256" alt="tile_test_1" src="https://github.com/user-attachments/assets/8210bea6-98ce-4031-ad13-7e3062cc5812" />

As a style param:
```
style['frame'] = frame
src = large_image.open(path, projection=projection, style=style, encoding='PNG')
tile = src.getTile(**tile_params)
```
<img width="256" height="256" alt="tile_test_2" src="https://github.com/user-attachments/assets/d6d3d769-020e-4631-812a-baecaf80d888" />


When `frame` is only expressed via style, the transparency mask applied to the tile will belong to the first frame but visible values will belong to the specified frame.