### PR TITLE
Alternative cache options

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,22 @@ urlpatterns = [
 ] + router.urls
 ```
 
+### Optional Cache Configuration
+
+Large Image leverages a cache to optimize performance (see [Large Image caching docs](https://girder.github.io/large_image/caching.html)). By default, `django-large-image` will use a Django-based cache. You may also use certain settings to customize the caching behavior and/or use a different cache backend.
+
+The [Large Image configuration options](https://girder.github.io/large_image/config_options.html) specify several cache options, all prefixed with `cache_`. To set any of these options, specify them in the settings of your Django app as all-caps attributes prefixed with `LARGE_IMAGE_`. For example, to set Redis as your cache backend, you may specify the following settings:
+
+```
+LARGE_IMAGE_CACHE_BACKEND = "redis"
+LARGE_IMAGE_CACHE_REDIS_URL = [redis_url]
+LARGE_IMAGE_CACHE_REDIS_USERNAME = [redis_username]
+LARGE_IMAGE_CACHE_REDIS_PASSWORD = [redis_password]
+```
+
+In addition to the configuration options listed in the docs linked above, one additional configuration option exists to set the name of the cache. You may set `LARGE_IMAGE_CACHE_NAME` as any string value. Otherwise, the name will simply be "default".
+
+
 And that's it!
 
 ### 📝 Example Code

--- a/demo/manage.py
+++ b/demo/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 

--- a/django_large_image/apps.py
+++ b/django_large_image/apps.py
@@ -35,6 +35,6 @@ class DjangoLargeImageConfig(AppConfig):
             'cache_sources',
         ]:
             settings_attr_name = 'LARGE_IMAGE_' + config_var_name.upper()
-            settings_attr_value = getattr(settings, settings_attr_name)
+            settings_attr_value = getattr(settings, settings_attr_name, None)
             if settings_attr_value is not None:
                 large_image.config.setConfig(config_var_name, settings_attr_value)

--- a/django_large_image/apps.py
+++ b/django_large_image/apps.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.apps import AppConfig
+from django.conf import settings
 import large_image
 
 logger = logging.getLogger(__name__)
@@ -13,6 +14,27 @@ class DjangoLargeImageConfig(AppConfig):
 
     def ready(self):
         # Set up cache with large_image
-        # This isn't necessary but it makes sure we always default
-        #   to the django cache if others are available
-        large_image.config.setConfig('cache_backend', 'django')
+        # Use any existing settings defined by other installed apps,
+        # Defaulting to caching with django
+        large_image.config.setConfig(
+            'cache_backend',
+            getattr(settings, 'LARGE_IMAGE_CACHE_BACKEND', 'django'),
+        )
+
+        # Set any other cache config if settings are defined
+        for config_var_name in [
+            'cache_python_memory_portion',
+            'cache_memcached_url',
+            'cache_memcached_username',
+            'cache_memcached_password',
+            'cache_redis_url',
+            'cache_redis_username',
+            'cache_redis_password',
+            'cache_tilesource_memory_portion',
+            'cache_tilesource_maximum',
+            'cache_sources',
+        ]:
+            settings_attr_name = 'LARGE_IMAGE_' + config_var_name.upper()
+            settings_attr_value = getattr(settings, settings_attr_name)
+            if settings_attr_value is not None:
+                large_image.config.setConfig(config_var_name, settings_attr_value)

--- a/django_large_image/cache.py
+++ b/django_large_image/cache.py
@@ -65,9 +65,9 @@ class DjangoCache(BaseCache):
     def getCache():  # noqa: N802
         try:
             name = getattr(settings, 'LARGE_IMAGE_CACHE_NAME', 'default')
-            dajngo_cache = caches[name]
+            django_cache = caches[name]
         except ImproperlyConfigured:  # pragma: no cover
             raise TileCacheConfigurationError
         cache_lock = threading.Lock()
-        cache = DjangoCache(dajngo_cache, alias=name)
+        cache = DjangoCache(django_cache, alias=name)
         return cache, cache_lock


### PR DESCRIPTION
This PR adjusts the large image cache config according to the presence of certain django settings. The list of available cache config options comes from https://girder.github.io/large_image/config_options.html.

(This PR also fixes a minor typo in the django cache definition and a whitespace linting error)